### PR TITLE
fix: NT choose twitch account name If twitch user uses CJK string.

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -105,8 +105,10 @@ async function createWindow() {
         mainWindow.loadURL('app://./index.html')
         autoUpdater.checkForUpdatesAndNotify()
     }
+}
 
-
+function isDisplayableName(username) {
+    return !/[^#$%&=@()!?_<>\[\]A-Z0-9a-z]/.test(username)
 }
 
 ipcMain.on("update_mod", (event, gamePath) => {
@@ -136,7 +138,10 @@ ipcMain.on("TRY_LOGIN", async (event, account) => {
             },
             responseType: 'json'
         })
-        const { display_name, ticket, id, e } = body
+
+        const { ticket, id, e } = body
+        const display_name = isDisplayableName(body.display_name) ? body.display_name : account
+
         appEvent("USER_EXTRA", e)
         wsClient({
             display_name,


### PR DESCRIPTION
# What is this?

Noita's SpriteComponent can not show CJK charactors(displayed as “??????”).
So I changed display-name to username, when display-name can not display in noita.

twitch-integration had same problem.
>https://github.com/soler91/Noita-Twitch-Integration/pull/48
>https://github.com/soler91/Noita-Twitch-Integration/commit/e4649fb2f3431371a7e9d16680f50aaef9b6590c