### PR TITLE
fix sanic effect will never end

### DIFF
--- a/files/effects/sanic/end.lua
+++ b/files/effects/sanic/end.lua
@@ -1,13 +1,14 @@
-local entity_id = GetUpdatedEntityID()
-local x, y = EntityGetTransform(entity_id)
-local owner = EntityGetClosestWithTag(x, y, "mortal")
+dofile_once("mods/noita-nemesis/files/scripts/utils.lua")
 
-local lua_components = EntityGetComponent(owner, "LuaComponent")
-if (lua_components ~= nil) then
-    for _, component in ipairs(lua_components) do
-        local damage_script_name = ComponentGetValue2(component, "script_damage_received")
-        if (damage_script_name ~= nil and damage_script_name == "mods/noita-nemesis/files/effects/sanic/damage.lua") then
-            EntityRemoveComponent(owner, component)
+local owner = get_player()
+if (owner ~= nil) then
+    local lua_components = EntityGetComponent(owner, "LuaComponent")
+    if (lua_components ~= nil) then
+        for _, component in ipairs(lua_components) do
+            local damage_script_name = ComponentGetValue2(component, "script_damage_received")
+            if (damage_script_name ~= nil and damage_script_name == "mods/noita-nemesis/files/effects/sanic/damage.lua") then
+                EntityRemoveComponent(owner, component)
+            end
         end
     end
 end


### PR DESCRIPTION
## Issuse
In most cases, the sanic effect never ends.

## Cause
end.lua targeting a different entity than at the start.
