### PR TITLE
Added opacity config for player ghosts

### DIFF
--- a/files/scripts/playerghost.lua
+++ b/files/scripts/playerghost.lua
@@ -176,22 +176,29 @@ if (visible) then
         movement = ConvertTableToStr(movement)
         local anim = anims_s[current.a] or anims_s[1]
         tx, ty = vec_lerp(x, y, current.x, current.y, 0.869)
+        local alpha = ModSettingGet("noita-together.NT_GHOST_OPACITY")
         EntitySetTransform(entity_id, tx, ty, 0, current.scale_x)
         for _, compid in pairs(platcomp) do
             ComponentSetValue2(compid, "rect_animation", anim)
+            ComponentSetValue2(compid, "alpha", alpha)
         end
         for _, child in pairs(EntityGetAllChildren(entity_id)) do
             local name = EntityGetName(child)
-            if (name == "held_item") then
-                local sprite_comp = EntityGetFirstComponent(child, "SpriteComponent")
-                local sprite = ComponentGetValue2(sprite_comp, "image_file")
-                if (sprite ~= held_wand and held_wand ~= "") then
-                    ComponentSetValue2(sprite_comp, "image_file", held_wand)
-                end
-            end
             if (name == "arm_r" or name == "held_item") then
                 local ax, ay = EntityGetTransform(child)
+                local sprite_comp = EntityGetFirstComponent(child, "SpriteComponent")
                 EntitySetTransform(child, ax, ay, arm.r, 1, arm.sy)
+                if (name == "held_item") then
+                    local sprite = ComponentGetValue2(sprite_comp, "image_file")
+                    if (sprite ~= held_wand and held_wand ~= "") then
+                        ComponentSetValue2(sprite_comp, "image_file", held_wand)
+                    end
+                end
+                ComponentSetValue2(sprite_comp, "alpha", alpha)
+            end
+            if (name == "player_name") then
+                local sprite_comp = EntityGetFirstComponent(child, "SpriteComponent")
+                ComponentSetValue2(sprite_comp, "alpha", alpha)
             end
         end
         ComponentSetValue2(dest_varcomp, "value_string", movement)

--- a/files/scripts/utils.lua
+++ b/files/scripts/utils.lua
@@ -321,6 +321,7 @@ function AppendName(entity, name)
             scale_y="0.7"
         }
         local name_entity = EntityCreateNew()
+        EntitySetName(name_entity, "player_name")
         EntityAddComponent(name_entity, "InheritTransformComponent", {
             _tags = "enabled_in_world",
             use_root_parent = "1"

--- a/settings.lua
+++ b/settings.lua
@@ -10,6 +10,15 @@ mod_settings =
 		value_default = true,
         scope=MOD_SETTING_SCOPE_RUNTIME
 	},
+	{
+		id = "NT_GHOST_OPACITY",
+		ui_name = "Player ghost opacity",
+		value_default = 1.0,
+		value_min = 0.0,
+		value_max = 1.0,
+		value_display_multiplier = 100,
+        scope=MOD_SETTING_SCOPE_RUNTIME
+	},
 }
 
 function ModSettingsUpdate( init_scope )


### PR DESCRIPTION
Players can be quite distracting, but it sucks to not see them at all, so I've implemented a slider (from 0 to 100) in mod config to change the opacity of players and their name-tags. Tested in a couple lobbies, only "bug" is player opacity not updating until they move, due to where opacity is updated in code. Personally, 20-30 opacity is a nice balance between distractability and player visibility.